### PR TITLE
Fix eslint-loader usage on production

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -26,7 +26,7 @@ module.exports = {
     ** Run ESLINT on save
     */
     extend (config, ctx) {
-      if (ctx.isClient) {
+      if (ctx.dev && ctx.isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,


### PR DESCRIPTION
So as `eslint-loader` placed to `devDependencies` it causes an error like:

```
ERROR in Entry module not found: Error: Can't resolve 'eslint-loader' in ...
```