### PR TITLE
remove unuse cross-env package

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
-    "cross-env": "^5.0.1",
     "express": "^4.15.3",
     "nuxt": "latest",
     "source-map-support": "^0.4.15"


### PR DESCRIPTION
I think cross-env package is unnecessary for this template, because the code has been removed here.

https://github.com/nuxt-community/express-template/commit/adf5f5fb5f7c18058f5ba768b40bf3dbf5725f86#diff-ebf2741126a75bcd0ccbf8df09b0f0fdL10