### PR TITLE
replace ctx.isClient to process.client due to nuxt-edge

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -26,7 +26,7 @@ module.exports = {
     ** Run ESLINT on save
     */
     extend (config, ctx) {
-      if (ctx.isDev && ctx.isClient) {
+      if (ctx.isDev && process.client) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,


### PR DESCRIPTION
**AS-IS**
 ERROR  Failed to compile with 1 errors                                friendly-errors 10:32:39

Module build failed (from ./node_modules/eslint-loader/index.js):      friendly-errors 10:32:39
TypeError: Cannot read property 'eslint' of undefined
    at Object.module.exports (/mnt/e/git-space/express-nuxt/node_modules/eslint-loader/index.js:148:18)

**TO-BE**
_No Compile Error_