### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-<p align="center"><img src="https://cloud.githubusercontent.com/assets/904724/22470179/b84f58d8-e7ce-11e6-995b-0933711ca566.png"></p>
+<p align="center"><img width="328px" src="https://nuxtjs.org/logos/nuxt.svg"></p>
 
 
 # Nuxt.js with Express
 
 > [ExpressJS](http://expressjs.com/) + [Nuxt.js](https://nuxtjs.org) = :zap:
+
+## Live Demo
+
+[https://express.nuxtjs.org](https://express.nuxtjs.org)
 
 ## Installation
 
@@ -19,8 +23,8 @@ npm install # or yarn install
 
 ## ExpressJS Changes
 
-- There is a  `server` directory with the root of your `express` server.
-- The `routes` directory is called `server/api`.
+- There is a  `api` directory with the root of your `api` server.
+- The `routes` directory is called `api/routes`.
 
 ## Commands
 
@@ -34,10 +38,6 @@ npm install # or yarn install
 
 We use [backpack](https://github.com/palmerhq/backpack) to watch and build the application, so you can use the latest ES6 features (module syntax, async/await, etc.).
 
-## Live Demo
-
-[https://express.nuxtjs.org](https://express.nuxtjs.org)
-
 ## Examples
 
 - [Handling Protected SSR Routes](https://github.com/nuxt/express/blob/master/protected-ssr-api.md)
@@ -47,9 +47,6 @@ We use [backpack](https://github.com/palmerhq/backpack) to watch and build the a
 - [ExpressJS](http://expressjs.com/en/guide/routing.html)
 - [Nuxt.js](https://nuxtjs.org/guide/)
 - [Vue.js](http://vuejs.org/guide/)
-
-## Alternative [Nuxt Express Module](https://github.com/uptownhr/nuxt-express-module)
-The module adds express into Nuxt's connect middleware stack using Nuxt's module system. The method will also handle hot reloading with out causing the nuxt build server to restart. 
 
 ## Licenses
 


### PR DESCRIPTION
Change Nuxt logo and Remove [Nuxt Express Module](https://github.com/uptownhr/nuxt-express-module) because it's deprecated