### PR TITLE
fix: Add Express as a Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@nuxt/http": "latest",
+    "express": "latest",
     "nuxt": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Adding Express as a local dependency to avoid needing it installed globally. Let me know if you want to call out a specific Express version.

Closes #191 